### PR TITLE
Enable auto switching between direct and amino signing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,11 +28,6 @@ const signerOptions: SignerOptions = {
   signingStargate: (_: unknown) => {
     return getSigningCosmosClientOptions();
   },
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  preferredSignType: (_: unknown) => {
-    // `preferredSignType` determines which signer is preferred for `getOfflineSigner` method. By default `amino`. It might affect the `OfflineSigner` used in `signingStargateClient` and `signingCosmwasmClient`. But if only one signer is provided, `getOfflineSigner` will always return this signer, `preferredSignType` won't affect anything.
-    return 'direct';
-  },
 };
 
 export default function App() {

--- a/src/hooks/useSwapTx.ts
+++ b/src/hooks/useSwapTx.ts
@@ -13,7 +13,7 @@ export const useSwapTx = (chainName: string) => {
     address: signerAddress,
     isWalletConnected,
     getRpcEndpoint,
-    getOfflineSignerDirect,
+    getOfflineSigner
   } = useChain(chainName);
   const { toast } = useToast();
 
@@ -54,7 +54,7 @@ export const useSwapTx = (chainName: string) => {
     try {
       const client = await getSigningOsmosisClient({
         rpcEndpoint: await getRpcEndpoint(),
-        signer: getOfflineSignerDirect(),
+        signer: getOfflineSigner(),
       });
 
       const swapMsg = swapSend({


### PR DESCRIPTION
I def have not exhaustively tested this but this seems to at least allow signing via amino/ledgers

<img width="324" alt="Screenshot 2024-09-15 at 15 45 04" src="https://github.com/user-attachments/assets/9c2a7493-55df-4357-9b35-3e8d354f39c6">
